### PR TITLE
Repalce "RTC" by "RTC_WAKEUP"

### DIFF
--- a/app/src/main/java/com/PKH/calendarmute/service/MuteService.java
+++ b/app/src/main/java/com/PKH/calendarmute/service/MuteService.java
@@ -152,7 +152,7 @@ public class MuteService extends Service {
 			// Remove previous alarms
 			alarmManager.cancel(pIntent);
 			// Add new alarm
-			alarmManager.set(AlarmManager.RTC, nextExecutionTime, pIntent);
+			alarmManager.set(AlarmManager.RTC_WAKEUP, nextExecutionTime, pIntent);
 		}
 	}
 	


### PR DESCRIPTION
I think this change should improve behaviour on later Android versions: it should prevent the alarm being delayed if the device happens to be asleep: see http://developer.android.com/reference/android/app/AlarmManager.html definition of RTC_WAKEUP. If you build with a targetSdkVersion 19 or later, you also need to change alarmManager.set to alarmManager.setExact in the same line, see the note about 20 lines from the top on the same web page.

Ignore the indentation changes which seem to be an artifact of the editor that I used. The only real change is at line 155.
